### PR TITLE
Fixed bower.json line link

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,4 +57,4 @@ Note, that this section is mostly relevant to Google engineers working on elemen
 * As with other open source code that Google releases, use the Apache 2.0 license.
 * Include a [LICENSE](https://github.com/GoogleWebComponents/google-chart/blob/master/LICENSE) file at the top level of your project.
 * Include a copyright comment in your [demo.html](https://github.com/GoogleWebComponents/google-youtube/blob/master/demo.html#L2) file.
-* Include "license": "Apache2" in your [bower.json](https://github.com/GoogleWebComponents/google-youtube/blob/master/bower.json#L10).
+* Include "license": "Apache2" in your [bower.json](https://github.com/GoogleWebComponents/google-youtube/blob/v0.0.4/bower.json#L16).


### PR DESCRIPTION
Thank you for this style-guide, it's really usefull. I took the liberty to fix this link. I know it's insignificant, but still..

It now links to tag v0.0.4 #L16 instead of master.

I think its good practice to always link to specific tags instead of master in these cases.. this way you ensure the reference to always be the same.
